### PR TITLE
Parsers for user-issued requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,11 +2,11 @@
 name = "proust"
 version = "0.0.1"
 dependencies = [
- "nom 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nom"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,11 +2,11 @@
 name = "proust"
 version = "0.0.1"
 dependencies = [
- "nom 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nom"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.0.1"
 authors = ["Clément Delafargue <clement@delafargue.name>", "Geoffroy Couprie <contact@geoffroycouprie.com>"]
 
 [dependencies]
-nom = "~0.2.0"
+nom = "~0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.0.1"
 authors = ["Clément Delafargue <clement@delafargue.name>", "Geoffroy Couprie <contact@geoffroycouprie.com>"]
 
 [dependencies]
-nom = "~0.3.0"
+nom = "~0.3.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 extern crate nom;
 
 use parser::primitive::*;
+use parser::request::*;
 use parser::metadata::*;
 
 mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,70 +2,11 @@
 #![allow(unused_imports)]
 
 #[macro_use]
-
 extern crate nom;
 
-use nom::{HexDisplay,Needed,IResult,FileProducer,be_u8,be_u16,be_u32,be_u64,be_f32};
-use nom::{Consumer,ConsumerState};
-use nom::IResult::*;
-use nom::Err::*;
+use parser::primitive::*;
 
-use std::str;
-use std::collections::HashMap;
-
-enum KafkaValue<'a> {
-    Int8(u8),
-    Int16(u16),
-    Int32(u32),
-    Int64(u64),
-    Bytes(&'a[u8]),
-    String(&'a[u8]),
-    Array(&'a[KafkaValue<'a>])
-}
-
-fn kafka_value<'a>(input: &'a[u8]) -> IResult<&'a[u8], KafkaValue<'a>> {
-    alt!(
-      input,
-      be_u8             => { |x| KafkaValue::Int8(x)   } |
-      be_u16            => { |x| KafkaValue::Int16(x)  } |
-      be_u32            => { |x| KafkaValue::Int32(x)  } |
-      be_u64            => { |x| KafkaValue::Int64(x)  } |
-      counted_bytes_u32 => { |x| KafkaValue::Bytes(x)  } |
-      counted_bytes_u16 => { |x| KafkaValue::String(x) }
-
-    )
-}
-
-fn counted_bytes_u32<'a>(input:&'a [u8]) -> IResult<&'a [u8], &'a [u8]> {
-  match be_u32(input) {
-    Done(i, length) => {
-      let sz: usize = (length - 4) as usize;
-      if i.len() >= sz {
-        return Done(&i[sz..], &i[0..sz])
-      } else {
-        return Incomplete(Needed::Size(length))
-      }
-    }
-    Error(e)      => Error(e),
-    Incomplete(e) => Incomplete(e)
-  }
-}
-
-fn counted_bytes_u16<'a>(input:&'a [u8]) -> IResult<&'a [u8], &'a [u8]> {
-  match be_u16(input) {
-    Done(i, length) => {
-      let sz: usize = (length - 4) as usize;
-      if i.len() >= sz {
-        return Done(&i[sz..], &i[0..sz])
-      } else {
-        return Incomplete(Needed::Size(length as u32))
-      }
-    }
-    Error(e)      => Error(e),
-    Incomplete(e) => Incomplete(e)
-  }
-}
-
+mod parser;
 
 fn main() {
     println!("Hello, world!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,73 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+#[macro_use]
+
+extern crate nom;
+
+use nom::{HexDisplay,Needed,IResult,FileProducer,be_u8,be_u16,be_u32,be_u64,be_f32};
+use nom::{Consumer,ConsumerState};
+use nom::IResult::*;
+use nom::Err::*;
+
+use std::str;
+use std::collections::HashMap;
+
+enum KafkaValue<'a> {
+    Int8(u8),
+    Int16(u16),
+    Int32(u32),
+    Int64(u64),
+    Bytes(&'a[u8]),
+    String(&'a[u8]),
+    Array(&'a[KafkaValue<'a>])
+}
+
+fn kafka_value<'a>(input: &'a[u8]) -> IResult<&'a[u8], KafkaValue<'a>> {
+    alt!(
+      input,
+      be_u8             => { |x| KafkaValue::Int8(x)   } |
+      be_u16            => { |x| KafkaValue::Int16(x)  } |
+      be_u32            => { |x| KafkaValue::Int32(x)  } |
+      be_u64            => { |x| KafkaValue::Int64(x)  } |
+      counted_bytes_u32 => { |x| KafkaValue::Bytes(x)  } |
+      counted_bytes_u16 => { |x| KafkaValue::String(x) }
+
+    )
+}
+
+fn counted_bytes_u32<'a>(input:&'a [u8]) -> IResult<&'a [u8], &'a [u8]> {
+  match be_u32(input) {
+    Done(i, length) => {
+      let sz: usize = (length - 4) as usize;
+      if i.len() >= sz {
+        return Done(&i[sz..], &i[0..sz])
+      } else {
+        return Incomplete(Needed::Size(length))
+      }
+    }
+    Error(e)      => Error(e),
+    Incomplete(e) => Incomplete(e)
+  }
+}
+
+fn counted_bytes_u16<'a>(input:&'a [u8]) -> IResult<&'a [u8], &'a [u8]> {
+  match be_u16(input) {
+    Done(i, length) => {
+      let sz: usize = (length - 4) as usize;
+      if i.len() >= sz {
+        return Done(&i[sz..], &i[0..sz])
+      } else {
+        return Incomplete(Needed::Size(length as u32))
+      }
+    }
+    Error(e)      => Error(e),
+    Incomplete(e) => Incomplete(e)
+  }
+}
+
+
 fn main() {
     println!("Hello, world!");
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,7 @@
 #[macro_use]
 extern crate nom;
 
-use parser::primitive::*;
 use parser::request::*;
-use parser::metadata::*;
-use parser::produce::*;
 
 mod parser;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ extern crate nom;
 use parser::primitive::*;
 use parser::request::*;
 use parser::metadata::*;
+use parser::produce::*;
 
 mod parser;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 extern crate nom;
 
 use parser::primitive::*;
+use parser::metadata::*;
 
 mod parser;
 

--- a/src/parser/consumer_metadata.rs
+++ b/src/parser/consumer_metadata.rs
@@ -1,0 +1,33 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use parser::primitive::*;
+
+use nom::{HexDisplay,Needed,IResult,FileProducer};
+use nom::{Consumer,ConsumerState};
+use nom::IResult::*;
+use nom::Err::*;
+
+pub type ConsumerMetadataRequest<'a> = KafkaString<'a>;
+
+pub fn consumer_metadata_request<'a>(input:&'a [u8]) -> IResult<&'a [u8], ConsumerMetadataRequest<'a>> {
+  kafka_string(input)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use nom::*;
+  use nom::IResult::*;
+
+  #[test]
+  fn consumer_metadata_request_tests() {
+      let input = &[
+        0x00, 0x00  //  ""
+      ];
+      let result = consumer_metadata_request(input);
+      let expected = &[][..];
+
+      assert_eq!(result, Done(&[][..], expected))
+  }
+}

--- a/src/parser/fetch.rs
+++ b/src/parser/fetch.rs
@@ -1,0 +1,117 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use parser::primitive::*;
+
+use nom::{HexDisplay,Needed,IResult,FileProducer, be_i16, be_i32, be_i64};
+use nom::{Consumer,ConsumerState};
+use nom::IResult::*;
+use nom::Err::*;
+
+#[derive(PartialEq,Debug)]
+pub struct FetchRequest<'a> {
+  replica_id: i32,
+  max_wait_time: i32,
+  min_bytes: i32,
+  topics: Vec<TopicFetch<'a>>
+}
+
+pub fn fetch_request<'a>(input:&'a [u8]) -> IResult<&'a [u8], FetchRequest<'a>> {
+  chain!(
+    input,
+    replica_id: be_i32 ~
+    max_wait_time: be_i32 ~
+    min_bytes: be_i32 ~
+    topics: call!(|i| { kafka_array(i, topic_fetch) }), || {
+      FetchRequest {
+        replica_id: replica_id,
+        max_wait_time: max_wait_time,
+        min_bytes: min_bytes,
+        topics: topics
+      }
+    }
+  )
+}
+
+#[derive(PartialEq,Debug)]
+pub struct TopicFetch<'a> {
+  topic_name: &'a [u8],
+  partitions: Vec<PartitionFetch>
+}
+
+pub fn topic_fetch<'a>(input:&'a [u8]) -> IResult<&'a [u8], TopicFetch<'a>> {
+  chain!(
+    input,
+    topic_name: kafka_string ~
+    partitions: call!(|i| { kafka_array(i, partition_fetch) }), || {
+      TopicFetch {
+        topic_name: topic_name,
+        partitions: partitions
+      }
+    }
+  )
+}
+
+#[derive(PartialEq,Debug)]
+pub struct PartitionFetch {
+  partition: i32,
+  fetch_offset: i64,
+  max_bytes: i32
+}
+
+pub fn partition_fetch<'a>(input:&'a [u8]) -> IResult<&'a [u8], PartitionFetch> {
+  chain!(
+    input,
+    partition: be_i32 ~
+    fetch_offset: be_i64 ~
+    max_bytes: be_i32, || {
+      PartitionFetch {
+        partition: partition,
+        fetch_offset: fetch_offset,
+        max_bytes: max_bytes
+      }
+    }
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use nom::*;
+  use nom::IResult::*;
+
+  #[test]
+  fn fetch_request_tests() {
+      let input = &[
+        0x00, 0x00, 0x00, 0x00, // replica_id = 0
+        0x00, 0x00, 0x00, 0x00, // max_wait_time = 0
+        0x00, 0x00, 0x00, 0x00, // min_bytes = 0
+        0x00, 0x00, 0x00, 0x01, // topics array length
+            0x00, 0x00,             //topic_name = ""
+            0x00, 0x00, 0x00, 0x01, // partitions array length
+                0x00, 0x00, 0x00, 0x00,                         //  partition = 0
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //  fetch_offset = 0
+                0x00, 0x00, 0x00, 0x00                          //  max_bytes = 0
+      ];
+      let result = fetch_request(input);
+      let expected = FetchRequest {
+        replica_id: 0,
+        max_wait_time: 0,
+        min_bytes: 0,
+        topics: vec![
+          TopicFetch {
+            topic_name: &[][..],
+            partitions: vec![
+              PartitionFetch {
+                partition: 0,
+                fetch_offset: 0,
+                max_bytes: 0
+              }
+            ]
+          }
+        ]
+      };
+
+      assert_eq!(result, Done(&[][..], expected))
+  }
+}

--- a/src/parser/message.rs
+++ b/src/parser/message.rs
@@ -8,9 +8,10 @@ use nom::{Consumer,ConsumerState};
 use nom::IResult::*;
 use nom::Err::*;
 
+#[derive(PartialEq, Debug)]
 pub struct TopicMessageSet<'a> {
-    topic_name: &'a [u8],
-    partitions: Vec<PartitionMessageSet<'a>>
+    pub topic_name: &'a [u8],
+    pub partitions: Vec<PartitionMessageSet<'a>>
 }
 
 pub fn topic_message_set<'a>(input: &'a [u8]) -> IResult<&'a [u8], TopicMessageSet<'a>> {
@@ -25,10 +26,11 @@ pub fn topic_message_set<'a>(input: &'a [u8]) -> IResult<&'a [u8], TopicMessageS
     })
 }
 
+#[derive(PartialEq, Debug)]
 pub struct PartitionMessageSet<'a> {
-    partition: i32,
-    message_set_size: i16,
-    message_set: MessageSet<'a>
+    pub partition: i32,
+    pub message_set_size: i16,
+    pub message_set: MessageSet<'a>
 }
 
 pub fn partition_message_set<'a>(input: &'a [u8]) -> IResult<&'a [u8], PartitionMessageSet<'a>> {
@@ -51,10 +53,11 @@ pub fn message_set<'a>(input: &'a [u8]) -> IResult<&'a [u8], MessageSet<'a>> {
   kafka_array(input, o_ms_message)
 }
 
+#[derive(PartialEq, Debug)]
 pub struct OMsMessage<'a> {
-    offset: i64,
-    message_size: i32,
-    message: Message<'a>
+    pub offset: i64,
+    pub message_size: i32,
+    pub message: Message<'a>
 }
 
 pub fn o_ms_message<'a>(input: &'a [u8]) -> IResult<&'a [u8], OMsMessage<'a>> {
@@ -73,11 +76,11 @@ pub fn o_ms_message<'a>(input: &'a [u8]) -> IResult<&'a [u8], OMsMessage<'a>> {
 
 #[derive(PartialEq, Debug)]
 pub struct Message<'a> {
-  crc: i32,
-  magic_byte: i8,
-  attributes: i8,
-  key: &'a [u8],
-  value: &'a [u8]
+  pub crc: i32,
+  pub magic_byte: i8,
+  pub attributes: i8,
+  pub key: &'a [u8],
+  pub value: &'a [u8]
 }
 
 pub fn message<'a>(input: &'a [u8]) -> IResult<&'a [u8], Message<'a>> {

--- a/src/parser/message.rs
+++ b/src/parser/message.rs
@@ -1,0 +1,127 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use parser::primitive::*;
+
+use nom::{HexDisplay,Needed,IResult,FileProducer, be_i8, be_i16, be_i32, be_i64};
+use nom::{Consumer,ConsumerState};
+use nom::IResult::*;
+use nom::Err::*;
+
+pub struct TopicMessageSet<'a> {
+    topic_name: &'a [u8],
+    partitions: Vec<PartitionMessageSet<'a>>
+}
+
+pub fn topic_message_set<'a>(input: &'a [u8]) -> IResult<&'a [u8], TopicMessageSet<'a>> {
+  chain!(
+    input,
+    topic_name: kafka_string ~
+    partitions: call!(|i| { kafka_array(i, partition_message_set) }), || {
+      TopicMessageSet {
+        topic_name: topic_name,
+        partitions: partitions
+      }
+    })
+}
+
+pub struct PartitionMessageSet<'a> {
+    partition: i32,
+    message_set_size: i16,
+    message_set: MessageSet<'a>
+}
+
+pub fn partition_message_set<'a>(input: &'a [u8]) -> IResult<&'a [u8], PartitionMessageSet<'a>> {
+  chain!(
+    input,
+    partition: be_i32 ~
+    message_set_size: be_i16 ~
+    message_set: message_set, || {
+      PartitionMessageSet {
+        partition: partition,
+        message_set_size: message_set_size,
+        message_set: message_set
+      }
+    })
+}
+
+pub type MessageSet<'a> = Vec<OMsMessage<'a>>;
+
+pub fn message_set<'a>(input: &'a [u8]) -> IResult<&'a [u8], MessageSet<'a>> {
+  kafka_array(input, o_ms_message)
+}
+
+pub struct OMsMessage<'a> {
+    offset: i64,
+    message_size: i32,
+    message: Message<'a>
+}
+
+pub fn o_ms_message<'a>(input: &'a [u8]) -> IResult<&'a [u8], OMsMessage<'a>> {
+  chain!(
+    input,
+    offset: be_i64 ~
+    message_size: be_i32 ~
+    message: message, || {
+      OMsMessage {
+        offset: offset,
+        message_size: message_size,
+        message: message
+      }
+    })
+}
+
+#[derive(PartialEq, Debug)]
+pub struct Message<'a> {
+  crc: i32,
+  magic_byte: i8,
+  attributes: i8,
+  key: &'a [u8],
+  value: &'a [u8]
+}
+
+pub fn message<'a>(input: &'a [u8]) -> IResult<&'a [u8], Message<'a>> {
+  chain!(
+    input,
+    crc: be_i32 ~
+    magic_byte: be_i8 ~
+    attributes: be_i8 ~
+    key: kafka_bytes ~
+    value: kafka_bytes, || {
+      Message {
+        crc: crc,
+        magic_byte: magic_byte,
+        attributes: attributes,
+        key: key,
+        value: value
+      }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use nom::*;
+  use nom::IResult::*;
+
+  #[test]
+  fn message_tests() {
+      let input = &[
+        0x00, 0x00, 0x00, 0x00, // crc = 0
+        0x00,                   // magic_byte = 0
+        0x00,                   // attributes = 0
+        0x00, 0x00, 0x00, 0x00, // key = []
+        0x00, 0x00, 0x00, 0x00  // value = []
+      ];
+      let result = message(input);
+      let expected = Message {
+        crc: 0,
+        magic_byte: 0,
+        attributes: 0,
+        key: &[][..],
+        value: &[][..]
+      };
+
+      assert_eq!(result, Done(&[][..], expected))
+  }
+}

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -1,0 +1,52 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use parser::primitive::*;
+
+use nom::{HexDisplay,Needed,IResult,FileProducer,be_u8,be_u16,be_u32,be_u64,be_f32};
+use nom::{Consumer,ConsumerState};
+use nom::IResult::*;
+use nom::Err::*;
+
+// ToDo according to the doc, api_key denotes the type of the request payload.
+// Need to investigate on this since the documentation is unclear
+pub struct RequestMessage<'a> {
+    api_key: i16,
+    api_version: i16,
+    correlation_id: i32,
+    client_id: &'a [u8],
+    request_payload: &'a RequestPayload<'a>
+}
+
+// ToDo other requests
+pub enum RequestPayload<'a> {
+    MetadataRequest(TopicMetadataRequest<'a>)
+}
+
+pub type TopicMetadataRequest<'a> = Vec<KafkaString<'a>>;
+
+pub fn topic_metadata_request<'a>(input:&'a [u8]) -> IResult<&'a [u8], TopicMetadataRequest<'a>> {
+  kafka_array(input, kafka_string)
+}
+
+// ToDo understand why the chain! macro doesn't work
+/*
+pub fn request_message<'a>(input:&'a [u8]) -> IResult<&'a [u8], &'a RequestMessage<'a>> {
+    chain!(
+      input,
+      key: be_i16 ~
+      version: be_i16 ~
+      correlation_id: be_i32 ~
+      client_id: kafka_string ~
+      payload: topic_metadata_request, || {
+          & RequestMessage {
+              api_key: key,
+              api_version: version,
+              correlation_id: correlation_id,
+              client_id: client_id,
+              request_payload: & RequestPayload::MetadataRequest(payload)
+          }
+      }
+    )
+}
+*/

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -8,45 +8,8 @@ use nom::{Consumer,ConsumerState};
 use nom::IResult::*;
 use nom::Err::*;
 
-// ToDo according to the doc, api_key denotes the type of the request payload.
-// Need to investigate on this since the documentation is unclear
-pub struct RequestMessage<'a> {
-    api_key: i16,
-    api_version: i16,
-    correlation_id: i32,
-    client_id: &'a [u8],
-    request_payload: &'a RequestPayload<'a>
-}
-
-// ToDo other requests
-pub enum RequestPayload<'a> {
-    MetadataRequest(TopicMetadataRequest<'a>)
-}
-
 pub type TopicMetadataRequest<'a> = Vec<KafkaString<'a>>;
 
 pub fn topic_metadata_request<'a>(input:&'a [u8]) -> IResult<&'a [u8], TopicMetadataRequest<'a>> {
   kafka_array(input, kafka_string)
 }
-
-// ToDo understand why the chain! macro doesn't work
-/*
-pub fn request_message<'a>(input:&'a [u8]) -> IResult<&'a [u8], &'a RequestMessage<'a>> {
-    chain!(
-      input,
-      key: be_i16 ~
-      version: be_i16 ~
-      correlation_id: be_i32 ~
-      client_id: kafka_string ~
-      payload: topic_metadata_request, || {
-          & RequestMessage {
-              api_key: key,
-              api_version: version,
-              correlation_id: correlation_id,
-              client_id: client_id,
-              request_payload: & RequestPayload::MetadataRequest(payload)
-          }
-      }
-    )
-}
-*/

--- a/src/parser/metadata.rs
+++ b/src/parser/metadata.rs
@@ -3,7 +3,7 @@
 
 use parser::primitive::*;
 
-use nom::{HexDisplay,Needed,IResult,FileProducer,be_u8,be_u16,be_u32,be_u64,be_f32};
+use nom::{HexDisplay,Needed,IResult,FileProducer};
 use nom::{Consumer,ConsumerState};
 use nom::IResult::*;
 use nom::Err::*;
@@ -12,4 +12,22 @@ pub type TopicMetadataRequest<'a> = Vec<KafkaString<'a>>;
 
 pub fn topic_metadata_request<'a>(input:&'a [u8]) -> IResult<&'a [u8], TopicMetadataRequest<'a>> {
   kafka_array(input, kafka_string)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use nom::*;
+  use nom::IResult::*;
+
+  #[test]
+  fn topic_metadata_request_tests() {
+      let input = &[
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00  //  [""]
+      ];
+      let result = topic_metadata_request(input);
+      let expected = vec![&[][..]];
+
+      assert_eq!(result, Done(&[][..], expected))
+  }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,1 @@
+pub mod primitive;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7,3 +7,4 @@ pub mod offset;
 pub mod metadata;
 pub mod offset_commit;
 pub mod offset_fetch;
+pub mod consumer_metadata;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,4 +5,5 @@ pub mod message;
 pub mod fetch;
 pub mod offset;
 pub mod metadata;
+pub mod offset_commit;
 pub mod offset_fetch;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,3 +1,5 @@
 pub mod primitive;
 pub mod request;
 pub mod metadata;
+pub mod produce;
+pub mod message;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,6 @@
 pub mod primitive;
 pub mod request;
-pub mod metadata;
 pub mod produce;
 pub mod message;
+pub mod fetch;
+pub mod metadata;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,3 +5,4 @@ pub mod message;
 pub mod fetch;
 pub mod offset;
 pub mod metadata;
+pub mod offset_fetch;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,2 +1,3 @@
 pub mod primitive;
+pub mod request;
 pub mod metadata;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3,4 +3,5 @@ pub mod request;
 pub mod produce;
 pub mod message;
 pub mod fetch;
+pub mod offset;
 pub mod metadata;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,1 +1,2 @@
 pub mod primitive;
+pub mod metadata;

--- a/src/parser/offset.rs
+++ b/src/parser/offset.rs
@@ -1,0 +1,107 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use parser::primitive::*;
+
+use nom::{HexDisplay,Needed,IResult,FileProducer, be_i16, be_i32, be_i64};
+use nom::{Consumer,ConsumerState};
+use nom::IResult::*;
+use nom::Err::*;
+
+#[derive(PartialEq,Debug)]
+pub struct OffsetRequest<'a> {
+  replica_id: i32,
+  topics: Vec<TopicOffset<'a>>
+}
+
+pub fn offset_request<'a>(input:&'a [u8]) -> IResult<&'a [u8], OffsetRequest<'a>> {
+  chain!(
+    input,
+    replica_id: be_i32 ~
+    topics: call!(|i| { kafka_array(i, topic_offset) }), || {
+      OffsetRequest {
+        replica_id: replica_id,
+        topics: topics
+      }
+    }
+  )
+}
+
+#[derive(PartialEq,Debug)]
+pub struct TopicOffset<'a> {
+  topic_name: &'a [u8],
+  partitions: Vec<PartitionOffset>
+}
+
+pub fn topic_offset<'a>(input:&'a [u8]) -> IResult<&'a [u8], TopicOffset<'a>> {
+  chain!(
+    input,
+    topic_name: kafka_string ~
+    partitions: call!(|i| { kafka_array(i, partition_offset) }), || {
+      TopicOffset {
+        topic_name: topic_name,
+        partitions: partitions
+      }
+    }
+  )
+}
+
+#[derive(PartialEq,Debug)]
+pub struct PartitionOffset {
+  partition: i32,
+  time: i64,
+  max_number_of_offsets: i32
+}
+
+pub fn partition_offset<'a>(input:&'a [u8]) -> IResult<&'a [u8], PartitionOffset> {
+  chain!(
+    input,
+    partition: be_i32 ~
+    time: be_i64 ~
+    max_number_of_offsets: be_i32, || {
+      PartitionOffset {
+        partition: partition,
+        time: time,
+        max_number_of_offsets: max_number_of_offsets
+      }
+    }
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use nom::*;
+  use nom::IResult::*;
+
+  #[test]
+  fn offset_request_tests() {
+      let input = &[
+        0x00, 0x00, 0x00, 0x00, // replica_id = 0
+        0x00, 0x00, 0x00, 0x01, // topics array length
+            0x00, 0x00,             // topic_name = ""
+            0x00, 0x00, 0x00, 0x01, // partitions array length
+                0x00, 0x00, 0x00, 0x00,                         // partition = 0
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // time = 0
+                0x00, 0x00, 0x00, 0x00                          // max_number_of_offsets = 0
+      ];
+      let result = offset_request(input);
+      let expected = OffsetRequest {
+        replica_id: 0,
+        topics: vec![
+          TopicOffset {
+            topic_name: &[][..],
+            partitions: vec![
+              PartitionOffset {
+                partition: 0,
+                time: 0,
+                max_number_of_offsets: 0
+              }
+            ]
+          }
+        ]
+      };
+
+      assert_eq!(result, Done(&[][..], expected))
+  }
+}

--- a/src/parser/offset_commit.rs
+++ b/src/parser/offset_commit.rs
@@ -1,0 +1,136 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use parser::primitive::*;
+
+use nom::{HexDisplay,Needed,IResult,FileProducer, be_i16, be_i32, be_i64};
+use nom::{Consumer,ConsumerState};
+use nom::IResult::*;
+use nom::Err::*;
+
+
+#[derive(PartialEq,Debug)]
+pub struct OffsetCommitRequest<'a> {
+  consumer_group: &'a [u8],
+  consumer_group_generation_id: Option<i32>,
+  consumer_id: Option<&'a [u8]>,
+  retention_time: Option<i64>,
+  topics: Vec<TopicOffsetCommit<'a>>
+}
+
+pub fn offset_commit_request_v2<'a>(input:&'a [u8]) -> IResult<&'a [u8], OffsetCommitRequest<'a>> {
+  chain!(
+    input,
+    consumer_group: kafka_string ~
+    consumer_group_generation_id: be_i32 ~
+    consumer_id: kafka_string ~
+    retention_time: be_i64 ~
+    topics: call!(|i| { kafka_array(i, topic_offset_commit) }), || {
+      OffsetCommitRequest {
+        consumer_group: consumer_group,
+        consumer_group_generation_id: Option::Some(consumer_group_generation_id),
+        consumer_id: Option::Some(consumer_id),
+        retention_time: Option::Some(retention_time),
+        topics: topics
+      }
+    }
+  )
+}
+
+#[derive(PartialEq,Debug)]
+pub struct TopicOffsetCommit<'a> {
+  topic_name: &'a [u8],
+  partitions: Vec<PartitionOffsetCommit<'a>>
+}
+
+pub fn topic_offset_commit<'a>(input:&'a [u8]) -> IResult<&'a [u8], TopicOffsetCommit<'a>> {
+  chain!(
+    input,
+    topic_name: kafka_string ~
+    partitions: call!(|i| { kafka_array(i, partition_offset_commit) }), || {
+      TopicOffsetCommit {
+        topic_name: topic_name,
+        partitions: partitions
+      }
+    }
+  )
+}
+
+#[derive(PartialEq,Debug)]
+pub struct PartitionOffsetCommit<'a> {
+  partition: i32,
+  offset: i64,
+  metadata: &'a [u8]
+}
+
+pub fn partition_offset_commit<'a>(input:&'a [u8]) -> IResult<&'a [u8], PartitionOffsetCommit> {
+  chain!(
+    input,
+    partition: be_i32 ~
+    offset: be_i64 ~
+    metadata: kafka_string, || {
+      PartitionOffsetCommit {
+        partition: partition,
+        offset: offset,
+        metadata: metadata
+      }
+    }
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use nom::*;
+  use nom::IResult::*;
+
+/*
+ * v2
+OffsetCommitRequest => ConsumerGroup ConsumerGroupGenerationId ConsumerId RetentionTime [TopicName [Partition Offset Metadata]]
+  ConsumerGroupId => string
+  ConsumerGroupGenerationId => int32
+  ConsumerId => string
+  RetentionTime => int64
+  TopicName => string
+  Partition => int32
+  Offset => int64
+  Metadata => string
+  */
+
+  #[test]
+  fn offset_request_tests() {
+      let input = &[
+        0x00, 0x00,                                     // consumer_group = ""
+        0x00, 0x00, 0x00, 0x00,                         // consumer_group_generation_id = 0
+        0x00, 0x00,                                     // consumer_id = ""
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // retention_time = 0
+        0x00, 0x00, 0x00, 0x01, // topics array length
+            0x00, 0x00,             // topic_name = ""
+            0x00, 0x00, 0x00, 0x01, // partitions array length
+                0x00, 0x00, 0x00, 0x00,                         // partition = 0
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // offset = 0
+                0x00, 0x00                                      // metadata = ""
+      ];
+      let result = offset_commit_request_v2(input);
+      let expected = OffsetCommitRequest {
+        consumer_group: &[][..],
+        consumer_group_generation_id: Option::Some(0),
+        consumer_id: Option::Some(&[][..]),
+        retention_time: Option::Some(0),
+        topics: vec![
+          TopicOffsetCommit {
+            topic_name: &[][..],
+            partitions: vec![
+              PartitionOffsetCommit {
+                partition: 0,
+                offset: 0,
+                metadata: &[][..]
+              }
+            ]
+          }
+        ]
+      };
+
+      assert_eq!(result, Done(&[][..], expected))
+  }
+}

--- a/src/parser/offset_fetch.rs
+++ b/src/parser/offset_fetch.rs
@@ -1,0 +1,97 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use parser::primitive::*;
+
+use nom::{HexDisplay,Needed,IResult,FileProducer, be_i16, be_i32, be_i64};
+use nom::{Consumer,ConsumerState};
+use nom::IResult::*;
+use nom::Err::*;
+
+#[derive(PartialEq,Debug)]
+pub struct OffsetFetchRequest<'a> {
+  consumer_group: &'a [u8],
+  topics: Vec<TopicOffsetFetch<'a>>
+}
+
+pub fn offset_fetch_request<'a>(input:&'a [u8]) -> IResult<&'a [u8], OffsetFetchRequest<'a>> {
+  chain!(
+    input,
+    consumer_group: kafka_string ~
+    topics: call!(|i| { kafka_array(i, topic_offset_fetch) }), || {
+      OffsetFetchRequest{
+        consumer_group: consumer_group,
+        topics: topics
+      }
+    }
+  )
+}
+
+#[derive(PartialEq,Debug)]
+pub struct TopicOffsetFetch<'a> {
+  topic_name: &'a [u8],
+  partitions: Vec<PartitionOffsetFetch>
+}
+
+pub fn topic_offset_fetch<'a>(input:&'a [u8]) -> IResult<&'a [u8], TopicOffsetFetch<'a>> {
+  chain!(
+    input,
+    topic_name: kafka_string ~
+    partitions: call!(|i| { kafka_array(i, partition_offset_fetch) }), || {
+      TopicOffsetFetch {
+        topic_name: topic_name,
+        partitions: partitions
+      }
+    }
+  )
+}
+
+#[derive(PartialEq,Debug)]
+pub struct PartitionOffsetFetch {
+  partition: i32
+}
+
+pub fn partition_offset_fetch<'a>(input:&'a [u8]) -> IResult<&'a [u8], PartitionOffsetFetch> {
+  map!(input, be_i32, |p| { PartitionOffsetFetch { partition: p } })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use nom::*;
+  use nom::IResult::*;
+
+/*
+OffsetFetchRequest => ConsumerGroup [TopicName [Partition]]
+  ConsumerGroup => string
+  TopicName => string
+  Partition => int32
+  */
+
+  #[test]
+  fn offset_request_tests() {
+      let input = &[
+        0x00, 0x00,             // consumer_group = ""
+        0x00, 0x00, 0x00, 0x01, // topics array length
+            0x00, 0x00,             // topic_name = ""
+            0x00, 0x00, 0x00, 0x01, // partitions array length
+                0x00, 0x00, 0x00, 0x00 // partition = 0
+      ];
+      let result = offset_fetch_request(input);
+      let expected = OffsetFetchRequest {
+        consumer_group: &[][..],
+        topics: vec![
+          TopicOffsetFetch {
+            topic_name: &[][..],
+            partitions: vec![
+              PartitionOffsetFetch {
+                partition: 0
+              }
+            ]
+          }
+        ]
+      };
+
+      assert_eq!(result, Done(&[][..], expected))
+  }
+}

--- a/src/parser/primitive.rs
+++ b/src/parser/primitive.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 
-use nom::{HexDisplay,Needed,IResult,FileProducer,be_u8,be_u16,be_u32,be_u64,be_f32};
+use nom::{HexDisplay,Needed,IResult,FileProducer,be_i8,be_i16,be_i32,be_i64};
 use nom::{Consumer,ConsumerState};
 use nom::IResult::*;
 use nom::Err::*;
@@ -24,57 +24,6 @@ pub type KafkaInt32 = i32;
 pub type KafkaInt64 = i64;
 pub type KafkaBytes<'a> = &'a [u8];
 pub type KafkaString<'a> = &'a [u8];
-
-
-// ToDo remove these once they get integrated in nom
-pub fn be_i8<'a>(i:&'a [u8]) -> IResult<&'a [u8], i8> {
-  map!(i, be_u8, | x | { x as i8 })
-}
-
-pub fn be_i16<'a>(i:&'a [u8]) -> IResult<&'a [u8], i16> {
-  map!(i, be_u16, | x | { x as i16 })
-}
-
-pub fn be_i32<'a>(i:&'a [u8]) -> IResult<&'a [u8], i32> {
-  map!(i, be_u32, | x | { x as i32 })
-}
-
-pub fn be_i64<'a>(i:&'a [u8]) -> IResult<&'a [u8], i64> {
-  map!(i, be_u64, | x | { x as i64 })
-}
-
-
-#[test]
-fn i8_tests() {
-  assert_eq!(be_i8(&[0x00]), Done(&b""[..], 0));
-  assert_eq!(be_i8(&[0x7f]), Done(&b""[..], 127));
-  assert_eq!(be_i8(&[0xff]), Done(&b""[..], -1));
-  assert_eq!(be_i8(&[0x80]), Done(&b""[..], -128));
-}
-
-#[test]
-fn i16_tests() {
-  assert_eq!(be_i16(&[0x00, 0x00]), Done(&b""[..], 0));
-  assert_eq!(be_i16(&[0x7f, 0xff]), Done(&b""[..], 32767_i16));
-  assert_eq!(be_i16(&[0xff, 0xff]), Done(&b""[..], -1));
-  assert_eq!(be_i16(&[0x80, 0x00]), Done(&b""[..], -32768_i16));
-}
-
-#[test]
-fn i32_tests() {
-  assert_eq!(be_i32(&[0x00, 0x00, 0x00, 0x00]), Done(&b""[..], 0));
-  assert_eq!(be_i32(&[0x7f, 0xff, 0xff, 0xff]), Done(&b""[..], 2147483647_i32));
-  assert_eq!(be_i32(&[0xff, 0xff, 0xff, 0xff]), Done(&b""[..], -1));
-  assert_eq!(be_i32(&[0x80, 0x00, 0x00, 0x00]), Done(&b""[..], -2147483648_i32));
-}
-
-#[test]
-fn i64_tests() {
-  assert_eq!(be_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), Done(&b""[..], 0));
-  assert_eq!(be_i64(&[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]), Done(&b""[..], 9223372036854775807_i64));
-  assert_eq!(be_i64(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]), Done(&b""[..], -1));
-  assert_eq!(be_i64(&[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), Done(&b""[..], -9223372036854775808_i64));
-}
 
 pub fn kafka_bytes<'a>(input:&'a [u8]) -> IResult<&'a [u8], KafkaBytes<'a>> {
   match be_i32(input) {

--- a/src/parser/primitive.rs
+++ b/src/parser/primitive.rs
@@ -1,0 +1,159 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use nom::{HexDisplay,Needed,IResult,FileProducer,be_u8,be_u16,be_u32,be_u64,be_f32};
+use nom::{Consumer,ConsumerState};
+use nom::IResult::*;
+use nom::Err::*;
+
+use std::str;
+
+pub enum KafkaValue<'a> {
+    Int8(KafkaInt8),
+    Int16(KafkaInt8),
+    Int32(KafkaInt32),
+    Int64(KafkaInt64),
+    Bytes(&'a KafkaBytes<'a>),
+    String(&'a KafkaString<'a>),
+    Array(&'a Vec<KafkaValue<'a>>)
+}
+
+pub type KafkaInt8 = i8;
+pub type KafkaInt16 = i16;
+pub type KafkaInt32 = i32;
+pub type KafkaInt64 = i64;
+pub type KafkaBytes<'a> = &'a [u8];
+pub type KafkaString<'a> = &'a [u8];
+
+
+// ToDo remove these once they get integrated in nom
+pub fn be_i8<'a>(i:&'a [u8]) -> IResult<&'a [u8], i8> {
+  map!(i, be_u8, | x | { x as i8 })
+}
+
+pub fn be_i16<'a>(i:&'a [u8]) -> IResult<&'a [u8], i16> {
+  map!(i, be_u16, | x | { x as i16 })
+}
+
+pub fn be_i32<'a>(i:&'a [u8]) -> IResult<&'a [u8], i32> {
+  map!(i, be_u32, | x | { x as i32 })
+}
+
+pub fn be_i64<'a>(i:&'a [u8]) -> IResult<&'a [u8], i64> {
+  map!(i, be_u64, | x | { x as i64 })
+}
+
+
+#[test]
+fn i8_tests() {
+  assert_eq!(be_i8(&[0x00]), Done(&b""[..], 0));
+  assert_eq!(be_i8(&[0x7f]), Done(&b""[..], 127));
+  assert_eq!(be_i8(&[0xff]), Done(&b""[..], -1));
+  assert_eq!(be_i8(&[0x80]), Done(&b""[..], -128));
+}
+
+#[test]
+fn i16_tests() {
+  assert_eq!(be_i16(&[0x00, 0x00]), Done(&b""[..], 0));
+  assert_eq!(be_i16(&[0x7f, 0xff]), Done(&b""[..], 32767_i16));
+  assert_eq!(be_i16(&[0xff, 0xff]), Done(&b""[..], -1));
+  assert_eq!(be_i16(&[0x80, 0x00]), Done(&b""[..], -32768_i16));
+}
+
+#[test]
+fn i32_tests() {
+  assert_eq!(be_i32(&[0x00, 0x00, 0x00, 0x00]), Done(&b""[..], 0));
+  assert_eq!(be_i32(&[0x7f, 0xff, 0xff, 0xff]), Done(&b""[..], 2147483647_i32));
+  assert_eq!(be_i32(&[0xff, 0xff, 0xff, 0xff]), Done(&b""[..], -1));
+  assert_eq!(be_i32(&[0x80, 0x00, 0x00, 0x00]), Done(&b""[..], -2147483648_i32));
+}
+
+#[test]
+fn i64_tests() {
+  assert_eq!(be_i64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), Done(&b""[..], 0));
+  assert_eq!(be_i64(&[0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]), Done(&b""[..], 9223372036854775807_i64));
+  assert_eq!(be_i64(&[0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]), Done(&b""[..], -1));
+  assert_eq!(be_i64(&[0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), Done(&b""[..], -9223372036854775808_i64));
+}
+
+pub fn kafka_bytes<'a>(input:&'a [u8]) -> IResult<&'a [u8], KafkaBytes<'a>> {
+  match be_i32(input) {
+    Done(i, length) => {
+      let sz: usize = length as usize;
+      // ToDo handle -1 (null)
+      // ToDo handle other negative values (it's an error)
+      println!("length: {}", length);
+      println!("sz: {}, len: {}", sz, i.len());
+      if i.len() >= sz {
+        return Done(&i[sz..], &i[0..sz])
+      } else {
+        return Incomplete(Needed::Size(length as u32))
+      }
+    }
+    Error(e)      => Error(e),
+    Incomplete(e) => Incomplete(e)
+  }
+}
+
+pub fn kafka_string<'a>(input:&'a [u8]) -> IResult<&'a [u8], KafkaString<'a>> {
+  match be_i16(input) {
+    Done(i, length) => {
+      // ToDo handle -1 (null)
+      // ToDo handle other negative values (it's an error)
+      let sz: usize = length as usize;
+      if i.len() >= sz {
+        return Done(&i[sz..], &i[0..sz])
+      } else {
+        return Incomplete(Needed::Size(length as u32))
+      }
+    }
+    Error(e)      => Error(e),
+    Incomplete(e) => Incomplete(e)
+  }
+}
+
+pub fn kafka_array<'a, F,O>(input: &'a[u8], closure: F) -> IResult<&'a[u8], Vec<O> >
+ where F : Fn(&'a[u8]) -> IResult<&'a[u8], O> {
+   match be_i32(input) {
+    Done(i, size) => {
+      // ToDo handle negative values (it's an error)
+      count!(i, closure, size)
+    }
+    Error(e)      => Error(e),
+    Incomplete(e) => Incomplete(e)
+   }
+ }
+
+#[cfg(test)]
+
+mod tests {
+  use super::*;
+  use nom::*;
+  use nom::IResult::*;
+
+  #[test]
+  fn kafka_bytes_test() {
+    assert_eq!(kafka_bytes(&[0x00, 0x00, 0x00, 0x00]), Done(&[][..], &[][..]));
+    assert_eq!(kafka_bytes(&[0x00, 0x00, 0x00, 0x01]), Incomplete(Needed::Size(1)));
+    assert_eq!(kafka_bytes(&[0x00, 0x00, 0x00, 0x01, 0x00]), Done(&[][..], &[0x00][..]));
+    assert_eq!(kafka_bytes(&[0x00, 0x00, 0x00, 0x01, 0x00, 0x00]), Done(&[0x00][..], &[0x00][..]));
+  }
+
+  #[test]
+  fn kafka_string_test() {
+    assert_eq!(kafka_string(&[0x00, 0x00]), Done(&[][..], &[][..]));
+    assert_eq!(kafka_string(&[0x00, 0x01]), Incomplete(Needed::Size(1)));
+    assert_eq!(kafka_string(&[0x00, 0x01, 0x00]), Done(&[][..], &[0x00][..]));
+    assert_eq!(kafka_string(&[0x00, 0x01, 0x00, 0x00]), Done(&[0x00][..], &[0x00][..]));
+  }
+
+  #[test]
+  fn kafka_array_test() {
+    assert_eq!(kafka_array(&[0x00, 0x00, 0x00, 0x00], be_i8), Done(&[][..], vec![]));
+    assert_eq!(kafka_array(&[0x00, 0x00, 0x00, 0x01], be_i8), Incomplete(Needed::Unknown));
+    assert_eq!(kafka_array(&[0x00, 0x00, 0x00, 0x01, 0x00], be_i8), Done(&[][..], vec![0x00]));
+    assert_eq!(kafka_array(&[0x00, 0x00, 0x00, 0x01, 0x00, 0x00], be_i8), Done(&[0x00][..], vec![0x00]));
+  }
+}
+
+

--- a/src/parser/produce.rs
+++ b/src/parser/produce.rs
@@ -1,0 +1,43 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use parser::primitive::*;
+use parser::message::*;
+
+use nom::{HexDisplay,Needed,IResult,FileProducer, be_i16, be_i32};
+use nom::{Consumer,ConsumerState};
+use nom::IResult::*;
+use nom::Err::*;
+
+pub struct ProduceRequest<'a> {
+    required_acks: i16,
+    timeout: i32,
+    topics: Vec<TopicMessageSet<'a>>
+}
+
+pub fn produce_request<'a>(input:&'a [u8]) -> IResult<&'a [u8], ProduceRequest<'a>> {
+  chain!(
+    input,
+    acks: be_i16 ~
+    timeout: be_i32 ~
+    topics: call!(|i| { kafka_array(i, topic_message_set) }), || {
+      ProduceRequest {
+        required_acks: acks,
+        timeout: timeout,
+        topics: topics
+      }
+    }
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use nom::*;
+  use nom::IResult::*;
+
+  #[test]
+  fn produce_request_tests() {
+    
+  }
+}

--- a/src/parser/produce.rs
+++ b/src/parser/produce.rs
@@ -9,6 +9,7 @@ use nom::{Consumer,ConsumerState};
 use nom::IResult::*;
 use nom::Err::*;
 
+#[derive(PartialEq, Debug)]
 pub struct ProduceRequest<'a> {
     required_acks: i16,
     timeout: i32,
@@ -33,11 +34,63 @@ pub fn produce_request<'a>(input:&'a [u8]) -> IResult<&'a [u8], ProduceRequest<'
 #[cfg(test)]
 mod tests {
   use super::*;
+  use parser::message::*;
   use nom::*;
   use nom::IResult::*;
 
   #[test]
   fn produce_request_tests() {
-    
+      let input = &[
+        0x00, 0x00,             // required_acks = 0
+        0x00, 0x00, 0x00, 0x00, // timeout = 0
+        0x00, 0x00, 0x00, 0x01, // TopicMessageSet array length
+            // TopicMessageSet
+            0x00, 0x00,             // topic_name = ""
+            0x00, 0x00, 0x00, 0x01, // PartitionMessageSet array length
+                // PartitionMessageSet
+                0x00, 0x00, 0x00, 0x00, // partition = 0
+                0x00, 0x00,             // message_set_size = ToDo
+                0x00, 0x00, 0x00, 0x01, // message_set array length
+                    // OMsMessage
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // offset = 0
+                    0x00, 0x00, 0x00, 0x00,                         // message_size = ToDo
+                    // Message
+                    0x00, 0x00, 0x00, 0x00, // crc = 0
+                    0x00,                   // magic_byte = 0
+                    0x00,                   // attributes = 0
+                    0x00, 0x00, 0x00, 0x00, // key = []
+                    0x00, 0x00, 0x00, 0x00  // value = []
+
+      ];
+      let result = produce_request(input);
+
+      assert_eq!(result, Done(&[][..], ProduceRequest {
+        required_acks: 0,
+        timeout: 0,
+        topics: vec![
+          TopicMessageSet {
+            topic_name: &[][..],
+            partitions: vec![
+              PartitionMessageSet {
+                partition: 0,
+                message_set_size: 0,
+                message_set: vec![
+                  OMsMessage {
+                    offset: 0,
+                    message_size: 0,
+                    message: Message {
+                      crc: 0,
+                      magic_byte: 0,
+                      attributes: 0,
+                      key: &[][..],
+                      value: &[][..]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }));
   }
 }

--- a/src/parser/request.rs
+++ b/src/parser/request.rs
@@ -10,14 +10,16 @@ use nom::Err::*;
 
 use parser::metadata::*;
 
+#[derive(PartialEq,Debug)]
 pub struct RequestMessage<'a> {
     api_version: i16,
     correlation_id: i32,
     client_id: &'a [u8],
-    request_payload: &'a RequestPayload<'a>
+    request_payload: RequestPayload<'a>
 }
 
 // ToDo other requests
+#[derive(PartialEq,Debug)]
 pub enum RequestPayload<'a> {
     MetadataRequest(TopicMetadataRequest<'a>)
 }
@@ -41,24 +43,47 @@ pub fn parse_request_payload<'a>(api_key: i16, input:&'a [u8]) -> IResult<&'a [u
     }
 }
 
-// ToDo understand why the chain! macro doesn't work
-/*
-pub fn request_message<'a>(input:&'a [u8]) -> IResult<&'a [u8], &'a RequestMessage<'a>> {
+pub fn request_message<'a>(input:&'a [u8]) -> IResult<&'a [u8], RequestMessage<'a>> {
     chain!(
       input,
       key: be_i16 ~
       version: be_i16 ~
       correlation_id: be_i32 ~
       client_id: kafka_string ~
-      payload: topic_metadata_request, || {
-          & RequestMessage {
-              api_key: key,
+      payload: call!(|i| { parse_request_payload(key, i) }), || {
+          RequestMessage {
               api_version: version,
               correlation_id: correlation_id,
               client_id: client_id,
-              request_payload: & RequestPayload::MetadataRequest(payload)
+              request_payload: payload
           }
       }
     )
 }
-*/
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use nom::*;
+  use nom::IResult::*;
+
+  #[test]
+  fn request_message_test() {
+      let input = &[
+        0x00, 0x03,             // api_key = 3
+        0x00, 0x00,             // api_version = 0
+        0x00, 0x00, 0x00, 0x00, // correlation_id = 0
+        0x00, 0x00,             // client_id = ""
+        0x00, 0x00, 0x00, 0x00  // request_payload = []
+      ];
+      let result = request_message(input);
+      let expected = RequestMessage {
+        api_version: 0,
+        correlation_id: 0,
+        client_id: &[][..],
+        request_payload: RequestPayload::MetadataRequest(vec![])
+      };
+
+      assert_eq!(result, Done(&[][..], expected))
+  }
+}

--- a/src/parser/request.rs
+++ b/src/parser/request.rs
@@ -40,10 +40,14 @@ pub fn parse_request_payload<'a>(api_version: i16, api_key: i16, input:&'a [u8])
         1  => map!(input, fetch_request, |p| { RequestPayload::FetchRequest(p) }),
         2  => map!(input, offset_request, |p| { RequestPayload::OffsetRequest(p) }),
         3  => map!(input, topic_metadata_request, |p| { RequestPayload::MetadataRequest(p) }),
+
+        // Non user-facing control APIs
+        // Given proust topology, implementing all of them may not be necessary
         4  => Error(Code(1)), // LeaderAndIsr
         5  => Error(Code(1)), // StopReplica
         6  => Error(Code(1)), // UpdateMetadata
         7  => Error(Code(1)), // ControlledShutdown
+
         8  => {
           // ToDo move it back to parser::offset_commit
           match api_version {
@@ -55,9 +59,14 @@ pub fn parse_request_payload<'a>(api_version: i16, api_key: i16, input:&'a [u8])
         }
         9  => map!(input, offset_fetch_request, |p| { RequestPayload::OffsetFetchRequest(p) }),
         10 => Error(Code(1)), // ConsumerMetadata
+
+        // Not documented, but those exist in the code
+        // Given proust topology, implementing all of them may not be necessary
         11 => Error(Code(1)), // JoinGroup
         12 => Error(Code(1)), // Heartbeat
-        _  => Error(Code(2)) // ToDo proper error code
+
+        _  => Error(Code(2)) // ToDo proper error code. A generic error type would be nicer.
+                             // I'm looking at you, @Geal
     }
 }
 

--- a/src/parser/request.rs
+++ b/src/parser/request.rs
@@ -1,0 +1,64 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use parser::primitive::*;
+
+use nom::{HexDisplay,Needed,IResult,FileProducer,be_u8,be_u16,be_u32,be_u64,be_f32};
+use nom::{Consumer,ConsumerState};
+use nom::IResult::*;
+use nom::Err::*;
+
+use parser::metadata::*;
+
+pub struct RequestMessage<'a> {
+    api_version: i16,
+    correlation_id: i32,
+    client_id: &'a [u8],
+    request_payload: &'a RequestPayload<'a>
+}
+
+// ToDo other requests
+pub enum RequestPayload<'a> {
+    MetadataRequest(TopicMetadataRequest<'a>)
+}
+
+pub fn parse_request_payload<'a>(api_key: i16, input:&'a [u8]) -> IResult<&'a [u8], RequestPayload<'a>> {
+    match api_key {
+        0  => Error(Code(1)), // Produce
+        1  => Error(Code(1)), // Fetch
+        2  => Error(Code(1)), // Offsets
+        3  => map!(input, topic_metadata_request, |p| { RequestPayload::MetadataRequest(p) }),
+        4  => Error(Code(1)), // LeaderAndIsr
+        5  => Error(Code(1)), // StopReplica
+        6  => Error(Code(1)), // UpdateMetadata
+        7  => Error(Code(1)), // ControlledShutdown
+        8  => Error(Code(1)), // OffsetCommit
+        9  => Error(Code(1)), // OffsetFetch
+        10 => Error(Code(1)), // ConsumerMetadata
+        11 => Error(Code(1)), // JoinGroup
+        12 => Error(Code(1)), // Heartbeat
+        _  => Error(Code(2)) // ToDo proper error code
+    }
+}
+
+// ToDo understand why the chain! macro doesn't work
+/*
+pub fn request_message<'a>(input:&'a [u8]) -> IResult<&'a [u8], &'a RequestMessage<'a>> {
+    chain!(
+      input,
+      key: be_i16 ~
+      version: be_i16 ~
+      correlation_id: be_i32 ~
+      client_id: kafka_string ~
+      payload: topic_metadata_request, || {
+          & RequestMessage {
+              api_key: key,
+              api_version: version,
+              correlation_id: correlation_id,
+              client_id: client_id,
+              request_payload: & RequestPayload::MetadataRequest(payload)
+          }
+      }
+    )
+}
+*/

--- a/src/parser/request.rs
+++ b/src/parser/request.rs
@@ -10,6 +10,7 @@ use nom::Err::*;
 
 use parser::produce::*;
 use parser::fetch::*;
+use parser::offset::*;
 use parser::metadata::*;
 
 #[derive(PartialEq,Debug)]
@@ -25,6 +26,7 @@ pub struct RequestMessage<'a> {
 pub enum RequestPayload<'a> {
     ProduceRequest(ProduceRequest<'a>),
     FetchRequest(FetchRequest<'a>),
+    OffsetRequest(OffsetRequest<'a>),
     MetadataRequest(TopicMetadataRequest<'a>)
 }
 
@@ -32,7 +34,7 @@ pub fn parse_request_payload<'a>(api_key: i16, input:&'a [u8]) -> IResult<&'a [u
     match api_key {
         0  => map!(input, produce_request, |p| { RequestPayload::ProduceRequest(p) }),
         1  => map!(input, fetch_request, |p| { RequestPayload::FetchRequest(p) }),
-        2  => Error(Code(1)), // Offsets
+        2  => map!(input, offset_request, |p| { RequestPayload::OffsetRequest(p) }),
         3  => map!(input, topic_metadata_request, |p| { RequestPayload::MetadataRequest(p) }),
         4  => Error(Code(1)), // LeaderAndIsr
         5  => Error(Code(1)), // StopReplica

--- a/src/parser/request.rs
+++ b/src/parser/request.rs
@@ -8,8 +8,9 @@ use nom::{Consumer,ConsumerState};
 use nom::IResult::*;
 use nom::Err::*;
 
-use parser::metadata::*;
 use parser::produce::*;
+use parser::fetch::*;
+use parser::metadata::*;
 
 #[derive(PartialEq,Debug)]
 pub struct RequestMessage<'a> {
@@ -23,13 +24,14 @@ pub struct RequestMessage<'a> {
 #[derive(PartialEq,Debug)]
 pub enum RequestPayload<'a> {
     ProduceRequest(ProduceRequest<'a>),
+    FetchRequest(FetchRequest<'a>),
     MetadataRequest(TopicMetadataRequest<'a>)
 }
 
 pub fn parse_request_payload<'a>(api_key: i16, input:&'a [u8]) -> IResult<&'a [u8], RequestPayload<'a>> {
     match api_key {
         0  => map!(input, produce_request, |p| { RequestPayload::ProduceRequest(p) }),
-        1  => Error(Code(1)), // Fetch
+        1  => map!(input, fetch_request, |p| { RequestPayload::FetchRequest(p) }),
         2  => Error(Code(1)), // Offsets
         3  => map!(input, topic_metadata_request, |p| { RequestPayload::MetadataRequest(p) }),
         4  => Error(Code(1)), // LeaderAndIsr

--- a/src/parser/request.rs
+++ b/src/parser/request.rs
@@ -9,6 +9,7 @@ use nom::IResult::*;
 use nom::Err::*;
 
 use parser::metadata::*;
+use parser::produce::*;
 
 #[derive(PartialEq,Debug)]
 pub struct RequestMessage<'a> {
@@ -21,12 +22,13 @@ pub struct RequestMessage<'a> {
 // ToDo other requests
 #[derive(PartialEq,Debug)]
 pub enum RequestPayload<'a> {
+    ProduceRequest(ProduceRequest<'a>),
     MetadataRequest(TopicMetadataRequest<'a>)
 }
 
 pub fn parse_request_payload<'a>(api_key: i16, input:&'a [u8]) -> IResult<&'a [u8], RequestPayload<'a>> {
     match api_key {
-        0  => Error(Code(1)), // Produce
+        0  => map!(input, produce_request, |p| { RequestPayload::ProduceRequest(p) }),
         1  => Error(Code(1)), // Fetch
         2  => Error(Code(1)), // Offsets
         3  => map!(input, topic_metadata_request, |p| { RequestPayload::MetadataRequest(p) }),

--- a/src/parser/request.rs
+++ b/src/parser/request.rs
@@ -12,6 +12,7 @@ use parser::produce::*;
 use parser::fetch::*;
 use parser::offset::*;
 use parser::metadata::*;
+use parser::offset_fetch::*;
 
 #[derive(PartialEq,Debug)]
 pub struct RequestMessage<'a> {
@@ -27,7 +28,8 @@ pub enum RequestPayload<'a> {
     ProduceRequest(ProduceRequest<'a>),
     FetchRequest(FetchRequest<'a>),
     OffsetRequest(OffsetRequest<'a>),
-    MetadataRequest(TopicMetadataRequest<'a>)
+    MetadataRequest(TopicMetadataRequest<'a>),
+    OffsetFetchRequest(OffsetFetchRequest<'a>)
 }
 
 pub fn parse_request_payload<'a>(api_key: i16, input:&'a [u8]) -> IResult<&'a [u8], RequestPayload<'a>> {
@@ -41,7 +43,7 @@ pub fn parse_request_payload<'a>(api_key: i16, input:&'a [u8]) -> IResult<&'a [u
         6  => Error(Code(1)), // UpdateMetadata
         7  => Error(Code(1)), // ControlledShutdown
         8  => Error(Code(1)), // OffsetCommit
-        9  => Error(Code(1)), // OffsetFetch
+        9  => map!(input, offset_fetch_request, |p| { RequestPayload::OffsetFetchRequest(p) }),
         10 => Error(Code(1)), // ConsumerMetadata
         11 => Error(Code(1)), // JoinGroup
         12 => Error(Code(1)), // Heartbeat

--- a/src/parser/request.rs
+++ b/src/parser/request.rs
@@ -14,6 +14,7 @@ use parser::offset::*;
 use parser::metadata::*;
 use parser::offset_commit::*;
 use parser::offset_fetch::*;
+use parser::consumer_metadata::*;
 
 #[derive(PartialEq,Debug)]
 pub struct RequestMessage<'a> {
@@ -31,7 +32,8 @@ pub enum RequestPayload<'a> {
     OffsetRequest(OffsetRequest<'a>),
     MetadataRequest(TopicMetadataRequest<'a>),
     OffsetCommitRequest(OffsetCommitRequest<'a>),
-    OffsetFetchRequest(OffsetFetchRequest<'a>)
+    OffsetFetchRequest(OffsetFetchRequest<'a>),
+    ConsumerMetadataRequest(ConsumerMetadataRequest<'a>)
 }
 
 pub fn parse_request_payload<'a>(api_version: i16, api_key: i16, input:&'a [u8]) -> IResult<&'a [u8], RequestPayload<'a>> {
@@ -58,7 +60,7 @@ pub fn parse_request_payload<'a>(api_version: i16, api_key: i16, input:&'a [u8])
           }
         }
         9  => map!(input, offset_fetch_request, |p| { RequestPayload::OffsetFetchRequest(p) }),
-        10 => Error(Code(1)), // ConsumerMetadata
+        10 => map!(input, consumer_metadata_request, |p| { RequestPayload::ConsumerMetadataRequest(p) }),
 
         // Not documented, but those exist in the code
         // Given proust topology, implementing all of them may not be necessary

--- a/src/parser/request.rs
+++ b/src/parser/request.rs
@@ -3,7 +3,7 @@
 
 use parser::primitive::*;
 
-use nom::{HexDisplay,Needed,IResult,FileProducer,be_u8,be_u16,be_u32,be_u64,be_f32};
+use nom::{HexDisplay,Needed,IResult,FileProducer,be_i8,be_i16,be_i32,be_i64,be_f32};
 use nom::{Consumer,ConsumerState};
 use nom::IResult::*;
 use nom::Err::*;

--- a/src/parser/request.rs
+++ b/src/parser/request.rs
@@ -51,13 +51,8 @@ pub fn parse_request_payload<'a>(api_version: i16, api_key: i16, input:&'a [u8])
         7  => Error(Code(1)), // ControlledShutdown
 
         8  => {
-          // ToDo move it back to parser::offset_commit
-          match api_version {
-            0 => Error(Code(1)),
-            1 => Error(Code(1)),
-            2 => map!(input, offset_commit_request_v2, |p| { RequestPayload::OffsetCommitRequest(p) }),
-            _ => Error(Code(2))
-          }
+           let pp = |i| { offset_commit_request(i, api_version) };
+           map!(input, pp, |p| { RequestPayload::OffsetCommitRequest(p) })
         }
         9  => map!(input, offset_fetch_request, |p| { RequestPayload::OffsetFetchRequest(p) }),
         10 => map!(input, consumer_metadata_request, |p| { RequestPayload::ConsumerMetadataRequest(p) }),


### PR DESCRIPTION
This PR contains the ADT for user-issued requests, as well as the parsers.
Protocol v0, v1 and v2 are supported, minus compression which will be handled afterwards.

Parsers for internal requests are not implemented due to proust's topology.
