### PR TITLE
Fix the parsing of a producer request

### DIFF
--- a/examples/node-client/index.js
+++ b/examples/node-client/index.js
@@ -34,9 +34,11 @@ if (process.pid) {
 
 producer.on('ready', () => {
     console.log("Producer is ready");
+    const simpleMessage = 'hi';
+    const keyedMessage = new KeyedMessage('a', 'hi');
 
     producer.send([
-        { topic, messages: 'hi' },
+        { topic, messages: [ simpleMessage, keyedMessage ] },
     ],
     (err, result) => {
         console.log(err || result);


### PR DESCRIPTION
When a message doesn't contain a key, the protocol set the key part to : `[0xff,  0xff, 0xff, 0xff]`. That wasn't parse by our actual parser in [message.rs](https://github.com/Geal/proust/blob/d34a337e95e0c0cf6bd444c73b763ec759b25584/src/parser/message.rs#L147).

The `key` is of type bytes. Bytes uses a signed `int32` to specify the length of data.
If the key is null, the length is set to -1 so `0xffffffff` for a `signed int32`.

See [protocol_types](http://kafka.apache.org/protocol#protocol_types) for more details:
> #### Variable Length Primitives
> ....A length of -1 indicates null. string uses an....
