### PR TITLE
Add Api version request

### DIFF
--- a/src/parser/request.rs
+++ b/src/parser/request.rs
@@ -33,7 +33,8 @@ pub enum RequestPayload<'a> {
     MetadataRequest(TopicMetadataRequest<'a>),
     OffsetCommitRequest(OffsetCommitRequest<'a>),
     OffsetFetchRequest(OffsetFetchRequest<'a>),
-    ConsumerMetadataRequest(ConsumerMetadataRequest<'a>)
+    ConsumerMetadataRequest(ConsumerMetadataRequest<'a>),
+    ApiVersionsRequest,
 }
 
 pub fn parse_request_payload<'a>(input:&'a [u8], api_version: i16, api_key: i16) -> IResult<&'a [u8], RequestPayload<'a>> {
@@ -61,6 +62,8 @@ pub fn parse_request_payload<'a>(input:&'a [u8], api_version: i16, api_key: i16)
         // Given proust topology, implementing all of them may not be necessary
         11 => Error(ErrorKind::Custom(InputError::NotImplemented.to_int())), // JoinGroup
         12 => Error(ErrorKind::Custom(InputError::NotImplemented.to_int())), // Heartbeat
+
+        18 => Done(input, RequestPayload::ApiVersionsRequest), // ApiVersions
 
         _  => Error(ErrorKind::Custom(InputError::ParserError.to_int()))
     }

--- a/src/proust.rs
+++ b/src/proust.rs
@@ -1,7 +1,25 @@
 use parser::request::{RequestMessage,RequestPayload};
 use responses::response::{ResponseMessage,ResponsePayload};
 use responses::metadata::{MetadataResponse,Broker,TopicMetadata,PartitionMetadata};
+use responses::api_versions::{ApiVersionsResponse, ApiVersion };
 
+//TODO: Use const for the API_KEY
+/// api version =~ 0.9.0
+pub const API_VERSION_0_9_0: [ApiVersion; 13] = [
+  ApiVersion(0, 0, 0),
+  ApiVersion(1, 0, 0),
+  ApiVersion(2, 0, 0),
+  ApiVersion(3, 0, 0),
+  ApiVersion(8, 0, 2),
+  ApiVersion(9, 0, 0),
+  ApiVersion(10, 0, 0),
+  ApiVersion(11, 0, 0),
+  ApiVersion(12, 0, 0),
+  ApiVersion(13, 0, 0),
+  ApiVersion(14, 0, 0),
+  ApiVersion(15, 0, 0),
+  ApiVersion(16, 0, 0),
+];
 
 pub fn handle_request(req: RequestMessage) -> Result<ResponseMessage,u8> {
     match req.request_payload {
@@ -33,7 +51,18 @@ pub fn handle_request(req: RequestMessage) -> Result<ResponseMessage,u8> {
             correlation_id: req.correlation_id,
             response_payload: ResponsePayload::ProduceResponse(vec![( "topic1", vec![(0, 0, 1337)])])
         })
-      }
+      },
+      RequestPayload::ApiVersionsRequest => {
+        Ok(ResponseMessage {
+          correlation_id: req.correlation_id,
+          response_payload: ResponsePayload::ApiVersionsResponse(
+            ApiVersionsResponse {
+              error_code: 0,
+              api_versions: &API_VERSION_0_9_0,
+            }
+          ),
+        })
+      },
       _ => Err(0)
     }
 }

--- a/src/responses/api_versions.rs
+++ b/src/responses/api_versions.rs
@@ -1,0 +1,62 @@
+use parser::primitive::*;
+use nom::IResult::*;
+use responses::primitive::*;
+
+/// ApiKey version support tuple.
+/// 0: api key, 1: min version, 2: max version
+#[derive(Debug,PartialEq)]
+pub struct ApiVersion(pub i16, pub i16, pub i16);
+
+#[derive(Debug,PartialEq)]
+pub struct ApiVersionsResponse<'a> {
+  pub error_code: i16,
+  pub api_versions: &'a [ApiVersion],
+}
+
+pub fn ser_api_versions_response(r: ApiVersionsResponse, output: &mut Vec<u8>) -> () {
+  ser_i16(r.error_code, output);
+  ser_i32((r.api_versions.len() as i32) * 3 * 2, output);
+
+  for api_version in r.api_versions {
+    ser_i16(api_version.0, output);
+    ser_i16(api_version.1, output);
+    ser_i16(api_version.2, output);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use nom::*;
+  use nom::IResult::*;
+
+  const API_TEST_VERSION_0_1_0: [ApiVersion; 2] = [
+    ApiVersion(0, 1, 2),
+    ApiVersion(1, 0, 3),
+  ];
+
+  #[test]
+  fn ser_api_versions_response_test() {
+    let mut v: Vec<u8> = vec![];
+
+    ser_api_versions_response(
+      ApiVersionsResponse {
+        error_code: 0,
+        api_versions: &API_TEST_VERSION_0_1_0,
+      }, &mut v);
+
+    assert_eq!(&v[..], &[
+      0x00, 0x00, // error_code = 0
+
+      0x00, 0x00, 0x00, 0x0c, // API_TEST_VERSION_0_1_0 size
+
+      0x00, 0x00, // api key = 0
+      0x00, 0x01, // min version = 1
+      0x00, 0x02, // max version = 2
+
+      0x00, 0x01, // api key = 1
+      0x00, 0x00, // min version = 0
+      0x00, 0x03, // max version = 3
+    ][..]);
+  }
+}

--- a/src/responses/mod.rs
+++ b/src/responses/mod.rs
@@ -7,3 +7,4 @@ pub mod fetch;
 pub mod offset;
 pub mod offset_commit;
 pub mod offset_fetch;
+pub mod api_versions;

--- a/src/responses/response.rs
+++ b/src/responses/response.rs
@@ -17,7 +17,7 @@ use responses::fetch::*;
 use responses::offset::*;
 use responses::offset_commit::*;
 use responses::offset_fetch::*;
-
+use responses::api_versions::*;
 
 #[derive(Debug,PartialEq)]
 pub struct ResponseMessage<'a> {
@@ -33,7 +33,8 @@ pub enum ResponsePayload<'a> {
   FetchResponse(FetchResponse<'a>),
   OffsetResponse(OffsetResponse<'a>),
   OffsetCommitResponse(OffsetCommitResponse<'a>),
-  OffsetFetchResponse(OffsetFetchResponse<'a>)
+  OffsetFetchResponse(OffsetFetchResponse<'a>),
+  ApiVersionsResponse(ApiVersionsResponse<'a>),
 }
 
 pub fn ser_response_message(response: ResponseMessage, output: &mut Vec<u8>) -> () {
@@ -47,7 +48,8 @@ pub fn ser_response_message(response: ResponseMessage, output: &mut Vec<u8>) -> 
     ResponsePayload::FetchResponse(p) => ser_fetch_response(p, &mut r_output),
     ResponsePayload::OffsetResponse(p) => ser_offset_response(p, &mut r_output),
     ResponsePayload::OffsetCommitResponse(p) => ser_offset_commit_response(p, &mut r_output),
-    ResponsePayload::OffsetFetchResponse(p) => ser_offset_fetch_response(p, &mut r_output)
+    ResponsePayload::OffsetFetchResponse(p) => ser_offset_fetch_response(p, &mut r_output),
+    ResponsePayload::ApiVersionsResponse(p) => ser_api_versions_response(p, &mut r_output),
   }
 
   ser_i32(r_output.len() as i32, output);


### PR DESCRIPTION
This PR add the feature to support the ApiVersion request (`api_key = 18`).
I did this because `librdkafka` request the api versions before any other requests.